### PR TITLE
Add per-g-point cloud-condensate hook for canonical McICA

### DIFF
--- a/rrtmgp/rrtmgp.py
+++ b/rrtmgp/rrtmgp.py
@@ -120,6 +120,10 @@ class RRTMGP:
       use_scan: bool = False,
       zenith: float | None = None,
       irrad: float | None = None,
+      cloud_path_liq_lw_per_gpt: Array | None = None,
+      cloud_path_ice_lw_per_gpt: Array | None = None,
+      cloud_path_liq_sw_per_gpt: Array | None = None,
+      cloud_path_ice_sw_per_gpt: Array | None = None,
   ) -> dict[str, Array]:
     """Compute the local heating rate due to radiative transfer.
 
@@ -127,6 +131,13 @@ class RRTMGP:
     and the two-stream radiative transfer equation is solved for the net fluxes
     at the grid cell faces.  Based on the overall net radiative flux of the grid
     cell, a local heating rate is determined.
+
+    For canonical McICA, the caller can supply per-g-point cloud water paths
+    via `cloud_path_{liq,ice}_{lw,sw}_per_gpt`, each shaped
+    `[n_gpt_{lw,sw}, nx, ny, nz]`. When provided, these replace the broadcast
+    cloud paths derived from `q_liq` and `q_ice` inside the per-g-point loop,
+    so each g-point sees its own stochastic sub-column. The clear-sky branch
+    is unaffected.
 
     Returns:
       A dictionary containing the following keys:
@@ -201,6 +212,8 @@ class RRTMGP:
         cloud_r_eff_ice=cloud_r_eff_ice,
         cloud_path_ice=ice_water_path,
         use_scan=use_scan,
+        cloud_path_liq_per_gpt=cloud_path_liq_lw_per_gpt,
+        cloud_path_ice_per_gpt=cloud_path_ice_lw_per_gpt,
     )
     sw_fluxes = two_stream.solve_sw(
         p_ref_xxc,
@@ -214,6 +227,8 @@ class RRTMGP:
         cloud_r_eff_ice=cloud_r_eff_ice,
         cloud_path_ice=ice_water_path,
         use_scan=use_scan,
+        cloud_path_liq_per_gpt=cloud_path_liq_sw_per_gpt,
+        cloud_path_ice_per_gpt=cloud_path_ice_sw_per_gpt,
     )
 
     # Compute the heating rate in K/s.

--- a/rrtmgp/rte/all_sky_test.py
+++ b/rrtmgp/rte/all_sky_test.py
@@ -336,6 +336,115 @@ class AllSkyTest(unittest.TestCase):
         atol=0,
     )
 
+  def test_per_gpoint_cloud_path_reduces_to_broadcast(self):
+    """Per-g-point cloud paths must equal broadcast paths when sub-columns are
+    identical across all g-points.
+
+    This is the McICA-stratiform sanity check: if every stochastic sub-column
+    is the same as the mean cloud profile, McICA-style per-g-point inputs must
+    produce the same fluxes as the column-only API. Use the compact lookup
+    tables to keep n_gpt small enough for the broadcast to fit in memory.
+    """
+    site = 0
+    use_compact_lookup = True
+
+    (
+        pressure_allsites,
+        pressure_level_allsites,
+        temperature_allsites,
+        temperature_level_allsites,
+        vmr_profiles_allsites,
+        _,
+    ) = _setup_atmospheric_profiles()
+
+    radiation_params = _setup_radiation_params(use_compact_lookup)
+    atmos_state = atmospheric_state.from_config(
+        radiation_params.atmospheric_state_cfg
+    )
+    optics_lib = optics.optics_factory(radiation_params.optics, atmos_state.vmr)
+
+    n_horiz = 2
+    convert_to_3d = functools.partial(
+        test_util.convert_to_3d_array_and_tile, dim=2, num_repeats=n_horiz
+    )
+    sfc_temperature = temperature_level_allsites[site, 1] * jnp.ones(
+        (n_horiz, n_horiz), dtype=jnp.float_
+    )
+    vmr_fields = {
+        k: convert_to_3d(v[site, :]) for k, v in vmr_profiles_allsites.items()
+    }
+    p = convert_to_3d(pressure_allsites[site, :])
+    pressure_level = convert_to_3d(pressure_level_allsites[site, :])
+    temperature = convert_to_3d(temperature_allsites[site, :])
+
+    r_liq = 1.2e-5
+    r_ice = 9.5e-5 / 2
+    cld_path = 1e-2
+    ones = jnp.ones_like(p)
+    ind_valid_p_range = jnp.logical_and(p > 10000, p < 90000)
+    r_eff_liq = jnp.where(
+        jnp.logical_and(ind_valid_p_range, temperature > 263), r_liq * ones, 0.0
+    )
+    cld_path_liq = jnp.where(
+        jnp.logical_and(ind_valid_p_range, temperature > 263),
+        cld_path * ones,
+        0.0,
+    )
+    r_eff_ice = jnp.where(
+        jnp.logical_and(ind_valid_p_range, temperature < 273), r_ice * ones, 0.0
+    )
+    cld_path_ice = jnp.where(
+        jnp.logical_and(ind_valid_p_range, temperature < 273),
+        cld_path * ones,
+        0.0,
+    )
+
+    molecules = _air_molecules_per_area(pressure_level, vmr_fields['h2o'])
+
+    # Reference: column-only (broadcast) cloud paths.
+    ref_lw = two_stream.solve_lw(
+        p, temperature, molecules, optics_lib, atmos_state, vmr_fields,
+        sfc_temperature,
+        cloud_r_eff_liq=r_eff_liq, cloud_path_liq=cld_path_liq,
+        cloud_r_eff_ice=r_eff_ice, cloud_path_ice=cld_path_ice,
+    )
+    ref_sw = two_stream.solve_sw(
+        p, temperature, molecules, optics_lib, atmos_state, vmr_fields,
+        cloud_r_eff_liq=r_eff_liq, cloud_path_liq=cld_path_liq,
+        cloud_r_eff_ice=r_eff_ice, cloud_path_ice=cld_path_ice,
+    )
+
+    # Build per-g-point arrays by tiling the single profile across n_gpt.
+    n_gpt_lw = optics_lib.n_gpt_lw
+    n_gpt_sw = optics_lib.n_gpt_sw
+    cpl_lw_per_gpt = jnp.broadcast_to(cld_path_liq, (n_gpt_lw,) + cld_path_liq.shape)
+    cpi_lw_per_gpt = jnp.broadcast_to(cld_path_ice, (n_gpt_lw,) + cld_path_ice.shape)
+    cpl_sw_per_gpt = jnp.broadcast_to(cld_path_liq, (n_gpt_sw,) + cld_path_liq.shape)
+    cpi_sw_per_gpt = jnp.broadcast_to(cld_path_ice, (n_gpt_sw,) + cld_path_ice.shape)
+
+    # Per-g-point cloud paths must produce the same fluxes. Pass `None` for
+    # the broadcast paths to confirm precedence: the per-g-point input is the
+    # sole source of cloud condensate.
+    out_lw = two_stream.solve_lw(
+        p, temperature, molecules, optics_lib, atmos_state, vmr_fields,
+        sfc_temperature,
+        cloud_r_eff_liq=r_eff_liq, cloud_path_liq=None,
+        cloud_r_eff_ice=r_eff_ice, cloud_path_ice=None,
+        cloud_path_liq_per_gpt=cpl_lw_per_gpt,
+        cloud_path_ice_per_gpt=cpi_lw_per_gpt,
+    )
+    out_sw = two_stream.solve_sw(
+        p, temperature, molecules, optics_lib, atmos_state, vmr_fields,
+        cloud_r_eff_liq=r_eff_liq, cloud_path_liq=None,
+        cloud_r_eff_ice=r_eff_ice, cloud_path_ice=None,
+        cloud_path_liq_per_gpt=cpl_sw_per_gpt,
+        cloud_path_ice_per_gpt=cpi_sw_per_gpt,
+    )
+
+    for key in ('flux_up', 'flux_down', 'flux_net'):
+      np.testing.assert_allclose(out_lw[key], ref_lw[key], rtol=1e-6, atol=1e-6)
+      np.testing.assert_allclose(out_sw[key], ref_sw[key], rtol=1e-6, atol=1e-6)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/rrtmgp/rte/two_stream.py
+++ b/rrtmgp/rte/two_stream.py
@@ -133,6 +133,8 @@ def solve_lw(
     cloud_r_eff_ice: Array | None = None,
     cloud_path_ice: Array | None = None,
     use_scan: bool = False,
+    cloud_path_liq_per_gpt: Array | None = None,
+    cloud_path_ice_per_gpt: Array | None = None,
 ) -> dict[str, Array]:
   """Solves two-stream radiative transfer equation over the longwave spectrum.
 
@@ -165,6 +167,12 @@ def solve_lw(
     cloud_path_ice: The cloud ice water path in each atmospheric grid cell
       [kg/m²].
     use_scan: Whether to use scan or for loops for the recurrent operation.
+    cloud_path_liq_per_gpt: Optional per-g-point cloud liquid water path with
+      leading axis of size `n_gpt_lw`, e.g. shape `[n_gpt_lw, nx, ny, nz]`.
+      When provided, the per-g-point slice replaces `cloud_path_liq` inside the
+      g-point loop. Intended for McICA, where the upstream sub-column generator
+      produces a separate binary cloud profile per g-point.
+    cloud_path_ice_per_gpt: Same as above, for ice water path.
 
   Returns:
     A dictionary with the following entries (in units of W/m²):
@@ -179,6 +187,16 @@ def solve_lw(
     vmr_fields = _reindex_vmr_fields(vmr_fields, optics_lib.gas_optics_lw)
 
   def step_fn(igpt, cumulative_flux):
+    cpl = (
+        cloud_path_liq_per_gpt[igpt]
+        if cloud_path_liq_per_gpt is not None
+        else cloud_path_liq
+    )
+    cpi = (
+        cloud_path_ice_per_gpt[igpt]
+        if cloud_path_ice_per_gpt is not None
+        else cloud_path_ice
+    )
     optical_props_2stream = _compute_local_properties_lw(
         pressure,
         temperature,
@@ -188,9 +206,9 @@ def solve_lw(
         vmr_fields,
         sfc_temperature,
         cloud_r_eff_liq,
-        cloud_path_liq,
+        cpl,
         cloud_r_eff_ice,
-        cloud_path_ice,
+        cpi,
     )
 
     # Boundary conditions.
@@ -236,6 +254,8 @@ def solve_sw(
     cloud_r_eff_ice: Array | None = None,
     cloud_path_ice: Array | None = None,
     use_scan: bool = False,
+    cloud_path_liq_per_gpt: Array | None = None,
+    cloud_path_ice_per_gpt: Array | None = None,
 ) -> dict[str, Array]:
   """Solves the two-stream radiative transfer equation for shortwave.
 
@@ -264,6 +284,12 @@ def solve_sw(
     cloud_path_ice: The cloud ice water path in each atmospheric grid cell
       [kg/m²].
     use_scan: Whether to use scan or for loops for the recurrent operation.
+    cloud_path_liq_per_gpt: Optional per-g-point cloud liquid water path with
+      leading axis of size `n_gpt_sw`, e.g. shape `[n_gpt_sw, nx, ny, nz]`.
+      When provided, the per-g-point slice replaces `cloud_path_liq` inside the
+      g-point loop. Intended for McICA, where the upstream sub-column generator
+      produces a separate binary cloud profile per g-point.
+    cloud_path_ice_per_gpt: Same as above, for ice water path.
 
   Returns:
     A dictionary with the following entries (in units of W/m²):
@@ -279,6 +305,16 @@ def solve_sw(
     vmr_fields = _reindex_vmr_fields(vmr_fields, optics_lib.gas_optics_sw)
 
   def step_fn(igpt, partial_fluxes):
+    cpl = (
+        cloud_path_liq_per_gpt[igpt]
+        if cloud_path_liq_per_gpt is not None
+        else cloud_path_liq
+    )
+    cpi = (
+        cloud_path_ice_per_gpt[igpt]
+        if cloud_path_ice_per_gpt is not None
+        else cloud_path_ice
+    )
     sw_optical_props = optics_lib.compute_sw_optical_properties(
         pressure,
         temperature,
@@ -286,9 +322,9 @@ def solve_sw(
         igpt,
         vmr_fields,
         cloud_r_eff_liq,
-        cloud_path_liq,
+        cpl,
         cloud_r_eff_ice,
-        cloud_path_ice,
+        cpi,
     )
     optical_props_2stream = monochromatic_two_stream.sw_cell_properties(
         zenith,


### PR DESCRIPTION
## Summary

- Adds optional per-g-point cloud water path inputs to `RRTMGP.compute_heating_rate` and the `two_stream.solve_lw` / `solve_sw` solvers, so the upstream McICA sub-column generator in [jax-gcm](https://github.com/climate-analytics-lab/jax-gcm) can drive a separate binary cloud profile per g-point — the canonical McICA setup that has been blocked by the column-only API.
- LW and SW take separate arrays because `n_gpt_lw != n_gpt_sw`; per-g-point precedence is over the broadcast path. Effective radius stays per-cell (the McICA mask doesn't perturb in-cloud droplet/crystal size). Clear-sky branch is unchanged.
- Wires the [climate-analytics-lab/jax-gcm#467](https://github.com/climate-analytics-lab/jax-gcm/issues/467) Option 1.

## API

```python
rrtmgp.compute_heating_rate(
    ...,
    cloud_path_liq_lw_per_gpt=cpl_lw,  # [n_gpt_lw, nx, ny, nz]
    cloud_path_ice_lw_per_gpt=cpi_lw,  # [n_gpt_lw, nx, ny, nz]
    cloud_path_liq_sw_per_gpt=cpl_sw,  # [n_gpt_sw, nx, ny, nz]
    cloud_path_ice_sw_per_gpt=cpi_sw,  # [n_gpt_sw, nx, ny, nz]
)
```

The four kwargs are independent — passing only liquid (or only LW) is fine. From jax-gcm, build them as `path * mcica.generate_subcolumns(n_subcols=n_gpt, ...)` and forward.

## Test plan

- [x] New `test_per_gpoint_cloud_path_reduces_to_broadcast` in `rrtmgp/rte/all_sky_test.py`: when every sub-column equals the mean profile, the per-g-point API must match the column-only API to within `rtol=atol=1e-6` for both LW and SW. This is the stratiform sanity check from the issue's acceptance criteria.
- [x] Full suite: `pytest rrtmgp/` → **103 passed** (4 existing parameterized cloudy-sky tests in `all_sky_test.py` still pass).
- [ ] Downstream broken-cumulus validation in jax-gcm: McICA differs systematically (and physically correctly) from beam-split for broken-cumulus cases.
- [ ] Wire `CLOUD_OVERLAP_MCICA` in jax-gcm's `RadiationParameters.cloud_overlap` to switch between the existing beam-split path (broadcast cloud paths) and the new McICA path (per-g-point cloud paths) at the `radiation_scheme_rrtmgp` call site.
