### PR TITLE
Add build-system config and PyPI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Build and Publish to PyPI
+
+# Publishes a release when a GitHub Release is published.
+# Uses PyPI Trusted Publishing (OIDC) — no API tokens or secrets required.
+# One-time setup on PyPI: register this repo as a trusted publisher under the
+# project's "Publishing" settings (workflow file: release.yaml,
+# environment: pypi). See https://docs.pypi.org/trusted-publishers/
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Check distribution metadata
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/jax-rrtmgp
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "jax-rrtmgp"
 description = "JAX-based implementation of RRTMGP radiative transfer for atmospheric modeling."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.1"
+version = "0.1.0"
 license = {file = "LICENSE"}
 authors = [
     {name = "parkerjeff", email="parkerjeff@google.com"},
@@ -32,6 +36,9 @@ dev = [
     "pytest",
     "parameterized"
 ]
+
+[tool.setuptools.packages.find]
+include = ["rrtmgp*"]
 
 [tool.setuptools.package-data]
 rrtmgp = [


### PR DESCRIPTION
Adds everything needed to cut the first PyPI release of `jax-rrtmgp`.

## Changes
- **`pyproject.toml`**: add the missing `[build-system]` table (setuptools backend) so the package can actually be built; add explicit package discovery (`include = ["rrtmgp*"]`) so the stray `build/` dir doesn't confuse discovery; normalize version `0.1` → `0.1.0`.
- **`.github/workflows/release.yaml`**: on GitHub Release publish, build sdist+wheel, run `twine check`, and publish to PyPI via **Trusted Publishing (OIDC)** (no secrets).

## Verification
Built locally with `python -m build` — succeeds. All 13 NetCDF lookup tables + JSON/CSV data are bundled in the wheel, and `twine check` passes on both artifacts.

## Release procedure (after merge)
1. Merge this PR to `main`.
2. Create a GitHub Release with tag `v0.1.0`.
3. The workflow builds and publishes to PyPI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
