### PR TITLE
Stop broadcasting gas-optics tables per-column in solve_sw (#8)

### DIFF
--- a/rrtmgp/rte/all_sky_test.py
+++ b/rrtmgp/rte/all_sky_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import functools
 from typing import TypeAlias
 
@@ -444,6 +445,99 @@ class AllSkyTest(unittest.TestCase):
     for key in ('flux_up', 'flux_down', 'flux_net'):
       np.testing.assert_allclose(out_lw[key], ref_lw[key], rtol=1e-6, atol=1e-6)
       np.testing.assert_allclose(out_sw[key], ref_sw[key], rtol=1e-6, atol=1e-6)
+
+  def test_solve_sw_vmap_keeps_gas_optics_tables_shared(self):
+    """Regression guard for issue #8 (per-column gas-optics table broadcast).
+
+    When `solve_sw` is vmapped over columns with a per-column `zenith` (the GCM
+    use case), the loop-invariant gas-optics tables must remain a single shared
+    operand -- they must not be broadcast across the column batch. The shortwave
+    night handling used to be a `jax.lax.cond(zenith >= pi/2)` wrapping the
+    g-point loop; under `vmap` that cond lowered to a `select` that ran both
+    branches and broadcast the ~3 MB `kmajor` table across every column
+    (~31 GB of scratch at 9216 columns). This test confirms (1) no such
+    per-column table broadcast appears in the compiled HLO and (2) the
+    night-masking semantics survive `vmap`: columns with the sun at or below the
+    horizon return zero fluxes, and daytime columns match a direct single-column
+    solve.
+    """
+    site = 0
+    (
+        pressure_allsites,
+        pressure_level_allsites,
+        temperature_allsites,
+        _,
+        vmr_profiles_allsites,
+        _,
+    ) = _setup_atmospheric_profiles()
+    # Compact lookup keeps n_gpt small so the test compiles quickly.
+    radiation_params = _setup_radiation_params(use_compact_lookup=True)
+    atmos_state = atmospheric_state.from_config(
+        radiation_params.atmospheric_state_cfg
+    )
+    optics_lib = optics.optics_factory(radiation_params.optics, atmos_state.vmr)
+
+    convert_to_3d = functools.partial(
+        test_util.convert_to_3d_array_and_tile, dim=2, num_repeats=1
+    )
+    vmr_fields = {
+        k: convert_to_3d(v[site, :]) for k, v in vmr_profiles_allsites.items()
+    }
+    p = convert_to_3d(pressure_allsites[site, :])
+    pressure_level = convert_to_3d(pressure_level_allsites[site, :])
+    temperature = convert_to_3d(temperature_allsites[site, :])
+    molecules = _air_molecules_per_area(pressure_level, vmr_fields['h2o'])
+
+    # Per-column zeniths: a mix of daytime (< pi/2) and sun-below-horizon
+    # (>= pi/2) columns, so the predicate is genuinely batched under vmap.
+    zeniths = jnp.array([0.2, 0.7, 1.3, 1.7, 2.2, 2.9], dtype=jnp.float_)
+    n_col = int(zeniths.shape[0])
+    is_night = np.asarray(zeniths) >= 0.5 * np.pi
+
+    def run_col(zenith: Array) -> dict[str, Array]:
+      st = dataclasses.replace(atmos_state, zenith=zenith)
+      return two_stream.solve_sw(
+          p, temperature, molecules, optics_lib, st, vmr_fields
+      )
+
+    vmapped = jax.vmap(run_col)
+
+    # (1) Memory guard: the bug materialises an [n_col, *kmajor.shape] buffer.
+    # Match its leading dims in the optimized HLO; legitimate per-column buffers
+    # are shaped [n_col, nx, ny, nz] and never collide with the table dims.
+    hlo = jax.jit(vmapped).lower(zeniths).compile().as_text()
+    ks = optics_lib.gas_optics_sw.kmajor.shape  # e.g. (14, 60, 9, 112)
+    broadcast_needle = f'f32[{n_col},{ks[0]},{ks[1]},{ks[2]}'
+    self.assertNotIn(
+        broadcast_needle,
+        hlo,
+        msg=(
+            f'gas-optics kmajor table is broadcast per-column '
+            f'("{broadcast_needle}" found in compiled HLO); see issue #8.'
+        ),
+    )
+
+    # (2) Semantics guard under vmap.
+    out = vmapped(zeniths)
+    for key in ('flux_up', 'flux_down', 'flux_net'):
+      vals = np.asarray(out[key])
+      self.assertTrue(
+          np.all(np.isfinite(vals)), msg=f'{key} has non-finite values'
+      )
+      # Sun at/below horizon -> exactly zero flux.
+      np.testing.assert_array_equal(
+          vals[is_night], np.zeros_like(vals[is_night])
+      )
+      # Daytime columns carry nonzero shortwave flux.
+      self.assertTrue(np.any(vals[~is_night] != 0.0))
+
+    # Daytime vmap columns must match a direct single-column solve.
+    for i in np.nonzero(~is_night)[0]:
+      ref = run_col(zeniths[i])
+      for key in ('flux_up', 'flux_down', 'flux_net'):
+        np.testing.assert_allclose(
+            np.asarray(out[key][i]), np.asarray(ref[key]), rtol=1e-6, atol=1e-6
+        )
 
 
 if __name__ == '__main__':

--- a/rrtmgp/rte/two_stream.py
+++ b/rrtmgp/rte/two_stream.py
@@ -348,6 +348,23 @@ def solve_sw(
     )
     g_point_to_bnd_sw = optics_lib.gas_optics_sw.g_point_to_bnd
 
+  # Sun-at-or-below-horizon handling. This used to be a `jax.lax.cond` that
+  # skipped the entire g-point solve at night. That short-circuit is silently
+  # destroyed the moment a caller `vmap`s this solver over columns with a
+  # per-column `zenith` (the GCM use case): `vmap` lowers a `cond` with a
+  # batched predicate into a `select` that runs *both* branches and broadcasts
+  # every operand the day branch captures across the whole column batch --
+  # including the loop-invariant gas-optics `kmajor` table (~3 MB), which
+  # balloons to ~31 GB at ~9000 columns (issue #8). Computing unconditionally
+  # keeps those tables a single shared operand under `vmap`. To stay finite for
+  # the night columns (the raw `exp(-tau / cos(zenith))` terms in the shortwave
+  # solve diverge to +inf once `cos(zenith) <= 0`), the solve is fed a
+  # horizon-clamped zenith and the night columns are zeroed out afterwards.
+  night = zenith >= 0.5 * jnp.pi
+  # Overhead sun (cos = 1) is the most benign valid angle; the resulting night
+  # fluxes are masked to zero below, so this placeholder never reaches output.
+  safe_zenith = jnp.where(night, jnp.zeros_like(jnp.asarray(zenith)), zenith)
+
   def step_fn(igpt, partial_fluxes):
     cpl = (
         cloud_path_liq_per_gpt[igpt]
@@ -380,7 +397,7 @@ def solve_sw(
           sw_optical_props, aer_slice
       )
     optical_props_2stream = monochromatic_two_stream.sw_cell_properties(
-        zenith,
+        safe_zenith,
         sw_optical_props['optical_depth'],
         sw_optical_props['ssa'],
         sw_optical_props['asymmetry_factor'],
@@ -400,7 +417,7 @@ def solve_sw(
         optical_depth=sw_optical_props['optical_depth'],
         toa_flux=toa_flux,
         sfc_albedo_direct=sfc_albedo,
-        zenith=zenith,
+        zenith=safe_zenith,
         use_scan=use_scan,
     )
 
@@ -420,22 +437,20 @@ def solve_sw(
   flux_keys = ['flux_up', 'flux_down', 'flux_net']
   fluxes_0 = {key: jnp.zeros_like(temperature) for key in flux_keys}
 
-  def _compute_fluxes(_):
-    fluxes = jax.lax.fori_loop(0, optics_lib.n_gpt_sw, step_fn, fluxes_0)
-    # There are problematic values for the fluxes at the top boundary (the top
-    # halo), so fix using a quadratic polynomial to evaluate the flux at the top
-    # boundary.
-    for key in flux_keys:
-      fluxes[key] = _replace_top_flux(fluxes[key])
-    return fluxes
-
-  # Use JAX control flow to avoid Python boolean conversion on tracers
-  return jax.lax.cond(
-      zenith >= 0.5 * jnp.pi,
-      lambda _: fluxes_0,
-      _compute_fluxes,
-      operand=None,
-  )
+  fluxes = jax.lax.fori_loop(0, optics_lib.n_gpt_sw, step_fn, fluxes_0)
+  # There are problematic values for the fluxes at the top boundary (the top
+  # halo), so fix using a quadratic polynomial to evaluate the flux at the top
+  # boundary.
+  for key in flux_keys:
+    fluxes[key] = _replace_top_flux(fluxes[key])
+  # Zero out columns where the sun is at or below the horizon. `night` is a
+  # scalar (single column) or, under a column `vmap`, a per-column scalar; it
+  # broadcasts over the trailing spatial/vertical axes of each flux field.
+  fluxes = {
+      key: jnp.where(night, jnp.zeros_like(val), val)
+      for key, val in fluxes.items()
+  }
+  return fluxes
 
 
 def compute_heating_rate(


### PR DESCRIPTION
## Summary

Fixes #8 — the ~31 GB scratch buffer when passing ~9000 columns through the gas optics.

`solve_sw` wrapped the per-g-point loop in `jax.lax.cond(zenith >= π/2)` to skip the solve at night. Under the GCM's per-column `vmap` (with a per-column `zenith`), `vmap` lowers that `cond` into a `select` that runs **both** branches and **broadcasts every operand the day branch captures across the column batch** — including the loop-invariant `kmajor` gas-optics table (`f32[14,60,9,112]` ≈ 3.4 MB → `f32[9216,14,60,9,112]` ≈ **31 GB**). This is the memory half of #6, distinct from the lookup-throughput fix in #7, and it persists with either lookup backend (confirmed for both the one-hot/einsum and direct-gather paths).

The optimized-HLO path in the issue (`cond/branch_1_fun/while/body`) is exactly this `cond`'s day branch (`_compute_fluxes` is the `false_fun`).

## Fix

- Remove the `lax.cond`; run the g-point loop **unconditionally** so the tables stay a single shared operand under `vmap`.
- Feed the solve a horizon-clamped `safe_zenith = where(night, 0, zenith)` and **mask night columns to zero** at the end. The clamp keeps night columns finite (the raw `exp(-tau / cos(zenith))` terms diverge to `+inf` once `cos(zenith) ≤ 0`), which also makes forward-mode AD through night columns finite — an improvement over the old vmapped `select`, which already ran the night branch with infinities.

`solve_lw` never had a `cond`, so it was already broadcast-free and is untouched.

## Verification

| Check | Result |
|---|---|
| Real `solve_sw` under column `vmap` | **0** per-column kmajor broadcasts, **0.2 MB** compiled temp (was 433 MB per column copy; ~31 GB at 9216 cols) |
| old vs new outputs (day & night) | **bitwise identical** (max abs diff = 0.0) |
| Full suite `pytest rrtmgp/` | **109 passed, 18 subtests passed** |
| New regression test run against old code | **fails** (`f32[n_col,14,60,9` found in HLO) → genuine guard |
| Night-path forward-mode AD | finite |

Adds `all_sky_test.py::test_solve_sw_vmap_keeps_gas_optics_tables_shared`, which asserts no `f32[n_col, *kmajor.shape]` buffer appears in the vmapped HLO and that the night→zero / day-matches-single-column semantics survive `vmap`.

## Scope

This is the **memory** half of #8: it removes the per-column table broadcast so a single large column chunk fits (more occupancy, no `lax.map` serialisation), on top of the throughput win from #7. It does **not** reduce the night-time SW *compute* under `vmap` — `vmap` is SIMD and cannot skip individual lanes. Recovering that compute needs a coarser-grained, scalar-predicate gate at the GCM driver level (skip whole all-dark chunks/shards), tracked in [climate-analytics-lab/jax-gcm#516](https://github.com/climate-analytics-lab/jax-gcm/issues/516).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
