### PR TITLE
compute_heating_rate: add compute_lw / compute_sw band-skip flags

### DIFF
--- a/rrtmgp/rrtmgp.py
+++ b/rrtmgp/rrtmgp.py
@@ -127,6 +127,8 @@ class RRTMGP:
       vmr_fields: dict[str, Array] | None = None,
       aerosol_optics_lw: dict[str, Array] | None = None,
       aerosol_optics_sw: dict[str, Array] | None = None,
+      compute_lw: bool = True,
+      compute_sw: bool = True,
   ) -> dict[str, Array]:
     """Compute the local heating rate due to radiative transfer.
 
@@ -228,6 +230,15 @@ class RRTMGP:
     liq_water_path = _compute_cloud_path(rho_xxc, q_liq, self._dz, sg_map)
     ice_water_path = _compute_cloud_path(rho_xxc, q_ice, self._dz, sg_map)
 
+    # ``compute_lw`` / ``compute_sw`` let a caller solve only one band and skip
+    # the other entirely (a real compute saving, not a mask). The skipped band's
+    # fluxes are filled with zeros that match the computed band's shape, so all
+    # downstream diagnostics/heating-rate code is unchanged. At least one band
+    # must be computed. Use case: a GCM driver that runs LW everywhere but
+    # restricts the SW solve to the sunlit columns (jax-gcm #516).
+    if not (compute_lw or compute_sw):
+      raise ValueError("At least one of compute_lw / compute_sw must be True.")
+
     lw_fluxes = two_stream.solve_lw(
         p_ref_xxc,
         temperature,
@@ -244,7 +255,7 @@ class RRTMGP:
         cloud_path_liq_per_gpt=cloud_path_liq_lw_per_gpt,
         cloud_path_ice_per_gpt=cloud_path_ice_lw_per_gpt,
         aerosol_optics=aerosol_optics_lw,
-    )
+    ) if compute_lw else None
     sw_fluxes = two_stream.solve_sw(
         p_ref_xxc,
         temperature,
@@ -260,7 +271,13 @@ class RRTMGP:
         cloud_path_liq_per_gpt=cloud_path_liq_sw_per_gpt,
         cloud_path_ice_per_gpt=cloud_path_ice_sw_per_gpt,
         aerosol_optics=aerosol_optics_sw,
-    )
+    ) if compute_sw else None
+
+    # Fill the skipped band with zeros shaped like the computed band.
+    if lw_fluxes is None:
+      lw_fluxes = {k: jnp.zeros_like(v) for k, v in sw_fluxes.items()}
+    if sw_fluxes is None:
+      sw_fluxes = {k: jnp.zeros_like(v) for k, v in lw_fluxes.items()}
 
     # Compute the heating rate in K/s.
     lw_heating_rate = two_stream.compute_heating_rate(
@@ -333,7 +350,7 @@ class RRTMGP:
           cloud_path_ice=None,
           use_scan=use_scan,
           aerosol_optics=aerosol_optics_lw,
-      )
+      ) if compute_lw else None
       sw_fluxes_clearsky = two_stream.solve_sw(
           p_ref_xxc,
           temperature,
@@ -347,7 +364,13 @@ class RRTMGP:
           cloud_path_ice=None,
           use_scan=use_scan,
           aerosol_optics=aerosol_optics_sw,
-      )
+      ) if compute_sw else None
+      if lw_fluxes_clearsky is None:
+        lw_fluxes_clearsky = {
+            k: jnp.zeros_like(v) for k, v in sw_fluxes_clearsky.items()}
+      if sw_fluxes_clearsky is None:
+        sw_fluxes_clearsky = {
+            k: jnp.zeros_like(v) for k, v in lw_fluxes_clearsky.items()}
       # Compute the heating rate in K/s.
       lw_heating_rate_clearsky = two_stream.compute_heating_rate(
           lw_fluxes_clearsky['flux_net'], p_ref_xxc

--- a/rrtmgp/rrtmgp_test.py
+++ b/rrtmgp/rrtmgp_test.py
@@ -199,6 +199,48 @@ class RRTMGPVMROverrideTest(unittest.TestCase):
     )
 
 
+class RRTMGPBandSelectionTest(unittest.TestCase):
+  """``compute_lw`` / ``compute_sw`` skip a band cleanly (jax-gcm #516)."""
+
+  def test_band_selection_splits_cleanly(self):
+    cfg = _build_radiative_transfer_cfg()
+    rt = rrtmgp.RRTMGP(cfg, dz=500.0)
+    inputs = _build_inputs()
+
+    both = rt.compute_heating_rate(**inputs)
+    lw_only = rt.compute_heating_rate(**inputs, compute_sw=False)
+    sw_only = rt.compute_heating_rate(**inputs, compute_lw=False)
+
+    sw_keys = ('sw_flux_up_full', 'sw_flux_down_full')
+    lw_keys = ('lw_flux_up_full', 'lw_flux_down_full')
+
+    # The computed band is identical to the both-bands run; the skipped band
+    # is exactly zero.
+    for k in lw_keys:
+      np.testing.assert_array_equal(
+          np.asarray(lw_only[k]), np.asarray(both[k]))
+      np.testing.assert_array_equal(
+          np.asarray(sw_only[k]), np.zeros_like(np.asarray(both[k])))
+    for k in sw_keys:
+      np.testing.assert_array_equal(
+          np.asarray(sw_only[k]), np.asarray(both[k]))
+      np.testing.assert_array_equal(
+          np.asarray(lw_only[k]), np.zeros_like(np.asarray(both[k])))
+
+    # Total heating of the both-bands run is the sum of the single-band runs.
+    total = np.asarray(both[rrtmgp_common.KEY_STORED_RADIATION])
+    lw = np.asarray(lw_only[rrtmgp_common.KEY_STORED_RADIATION])
+    sw = np.asarray(sw_only[rrtmgp_common.KEY_STORED_RADIATION])
+    np.testing.assert_allclose(total, lw + sw, rtol=1e-6, atol=1e-12)
+
+  def test_both_bands_disabled_raises(self):
+    cfg = _build_radiative_transfer_cfg()
+    rt = rrtmgp.RRTMGP(cfg, dz=500.0)
+    inputs = _build_inputs()
+    with self.assertRaises(ValueError):
+      rt.compute_heating_rate(**inputs, compute_lw=False, compute_sw=False)
+
+
 class RRTMGPAerosolTest(unittest.TestCase):
   """Regression tests for the per-band aerosol_optics_{lw,sw} kwargs."""
 


### PR DESCRIPTION
## Summary

Adds `compute_lw` / `compute_sw` (both default `True`) to `RRTMGP.compute_heating_rate`. When one is `False`, that band's radiative-transfer solve (both all-sky and clear-sky) is **skipped entirely** and its fluxes are filled with zeros shaped like the computed band, so every downstream diagnostic and the heating-rate combination are unchanged. Requiring at least one band keeps the contract simple.

## Why

In a GCM the per-column scheme is `vmap`'d over the whole grid. At any instant roughly half the columns are dark, where the shortwave solve does no useful work — since #8 it already returns zero for night columns via the horizon mask, but the solve still *runs*. A driver can now run **LW on every column and SW only on the sunlit subset**, recovering that compute (jax-gcm [#516](https://github.com/climate-analytics-lab/jax-gcm/issues/516)). This is a pure compute saving; the night-zeroing behaviour from #8 is unchanged.

## Validation

New `RRTMGPBandSelectionTest` asserts:
- the computed band is bit-identical to the both-bands run,
- the skipped band is exactly zero,
- total heating of the both-bands run equals the sum of the two single-band runs,
- disabling both bands raises `ValueError`.

Used by the companion jax-gcm PR (single-`vmap` radiation + day/night SW compaction).