### PR TITLE
CI: guard releases against tag/version mismatch

### DIFF
--- a/.github/scripts/check_release_version.py
+++ b/.github/scripts/check_release_version.py
@@ -1,0 +1,76 @@
+"""Fail a release build when the git tag and the built package version disagree.
+
+Run in CI after ``python -m build``. Compares the release tag (e.g. ``v0.2.0``,
+passed as ``argv[1]`` from ``github.ref_name``) against the version of the wheel
+that was actually built into ``dist/``. Uses ``packaging`` so that normalised
+equivalents match (e.g. tag ``v0.1`` == built ``0.1.0``, ``v0.2.0a`` ==
+``0.2.0a0``).
+
+This guards against the failure mode where a ``vX.Y.Z`` release is cut without
+bumping ``version`` in ``pyproject.toml``: the build then produces an
+already-published ``X.Y.(Z-1)`` artifact and PyPI rejects it with an opaque
+``400 File already exists`` only after the build succeeds. Here we fail fast,
+before the publish job runs, with an actionable message.
+
+Usage::
+
+    python .github/scripts/check_release_version.py "$TAG" [dist_dir]
+"""
+
+import sys
+from pathlib import Path
+
+from packaging.utils import parse_wheel_filename
+from packaging.version import Version
+
+
+def main(argv: list[str]) -> int:
+  if len(argv) < 2:
+    print(
+        '::error::usage: check_release_version.py <tag> [dist_dir]',
+        file=sys.stderr,
+    )
+    return 2
+
+  tag = argv[1]
+  # Release tags are conventionally `vX.Y.Z`; the package version has no `v`.
+  expected = tag[1:] if tag[:1] in ('v', 'V') else tag
+  dist_dir = argv[2] if len(argv) > 2 else 'dist'
+
+  wheels = sorted(Path(dist_dir).glob('*.whl'))
+  if not wheels:
+    print(
+        f'::error::no wheel found in {dist_dir}/ -- did `python -m build` run?',
+        file=sys.stderr,
+    )
+    return 2
+
+  # parse_wheel_filename returns (name, Version, build_tag, tags).
+  built = parse_wheel_filename(wheels[0].name)[1]
+
+  try:
+    expected_version = Version(expected)
+  except Exception:  # noqa: BLE001 - surface a clear CI error, not a traceback.
+    print(
+        f'::error::release tag {tag!r} does not contain a PEP 440 version '
+        f'({expected!r}).',
+        file=sys.stderr,
+    )
+    return 1
+
+  if expected_version != built:
+    print(
+        f'::error::Release tag {tag!r} (version {expected_version}) does not '
+        f'match the built package version {built}. Bump `version` in '
+        f'pyproject.toml to {expected_version} (or fix the tag) before '
+        f'publishing.',
+        file=sys.stderr,
+    )
+    return 1
+
+  print(f'OK: release tag {tag} matches built package version {built}')
+  return 0
+
+
+if __name__ == '__main__':
+  raise SystemExit(main(sys.argv))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,16 @@ jobs:
         run: python -m pip install --upgrade pip build
       - name: Build sdist and wheel
         run: python -m build
+      - name: Verify release tag matches built version
+        # Fail fast if a vX.Y.Z release was cut without bumping `version` in
+        # pyproject.toml, instead of surfacing an opaque PyPI "400 File already
+        # exists" from the publish job. `github.ref_name` is passed via env to
+        # avoid script injection from the tag name.
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          python -m pip install --upgrade packaging
+          python .github/scripts/check_release_version.py "$TAG"
       - name: Check distribution metadata
         run: |
           python -m pip install --upgrade twine


### PR DESCRIPTION
## Summary

Adds a CI guard so a release can't reach PyPI when the git tag and the package version disagree.

### Why
The `v0.2.0` release built `jax_rrtmgp-0.1.0`, because the tag was cut from a commit where `pyproject.toml` still said `version = "0.1.0"`. The build *succeeded*; PyPI then rejected the upload with an opaque `400 File already exists` from the publish job. This turns that into an early, clear failure.

### What
- New step in the `build` job (right after `python -m build`, so it runs before the `publish` job that `needs: build`) comparing the release tag (`github.ref_name`, passed via env to avoid injection) against the version of the wheel actually built into `dist/`.
- Uses `packaging` for PEP 440 normalisation, so `v0.1` matches a built `0.1.0` and `v0.2.0a` matches `0.2.0a0` — no false positives from equivalent spellings.
- On mismatch it fails with a `::error::` annotation naming the fix (“bump `version` in pyproject.toml to X.Y.Z”), before PyPI is ever touched.
- Logic lives in `.github/scripts/check_release_version.py`, kept out of the YAML so it stays readable and testable.

### Tested
Ran the script against synthetic `dist/` wheels:

| tag | built wheel | result |
|---|---|---|
| `v0.2.0` | `0.2.0` | OK (rc 0) |
| `v0.2.0` | `0.1.0` | `::error::` mismatch (rc 1) |
| `v0.1` | `0.1.0` | OK — normalised (rc 0) |
| `v0.1` | _(none)_ | error: no wheel (rc 2) |

GitHub Actions runs the workflow definition from the **tagged commit**, so this takes effect for releases cut after it lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
