### PR TITLE
fix(gas_optics): make minor-absorber cond x64-safe (int dtype match)

### DIFF
--- a/rrtmgp/optics/gas_optics.py
+++ b/rrtmgp/optics/gas_optics.py
@@ -400,11 +400,17 @@ def _compute_minor_optical_depth(
     )
 
   minor_start_idx = minor_bnd_start[ibnd]
+  # Both branches must return the same integer dtype: ``minor_start_idx`` keeps
+  # the loaded table's int32, whereas ``jnp.int_`` is int64 when x64 is enabled
+  # (e.g. when a float64 host such as the MAM4-JAX aerosol core turns on
+  # ``jax_enable_x64``), so ``lax.cond`` would reject the int32/int64 mismatch.
+  # Pin the false branch to ``minor_start_idx``'s dtype so the cond is
+  # x64-agnostic.
   i0 = jax.lax.cond(
       minor_start_idx >= 0,
       true_fun=lambda: minor_start_idx,
       false_fun=lambda: jnp.array(
-          minor_absorber_intervals, dtype=jnp.int_
+          minor_absorber_intervals, dtype=minor_start_idx.dtype
       ),
   )
   tau_minor_0 = jnp.zeros_like(temperature)


### PR DESCRIPTION
## Problem

Under \`jax_enable_x64=True\`, tracing the gas optics fails:

\`\`\`
TypeError: cond branches must have equal output types but they differ.
The output of true_fun has type int32[] but the corresponding output of false_fun has type int64[]
\`\`\`

at \`gas_optics.py\` \`_compute_minor_optical_depth\`.

## Cause

The \`lax.cond\` picking the minor-absorber start index returns \`minor_start_idx\` (int32, indexed from the loaded k-distribution table) in the true branch and \`jnp.array(minor_absorber_intervals, dtype=jnp.int_)\` in the false branch. \`jnp.int_\` is **int32 when x64 is off but int64 when x64 is on**, so the two branches only agree in the default float32 build. It's latent there but a hard error under x64.

This surfaces when a float64 host enables x64 — e.g. driving jax-rrtmgp from JAX-GCM with the MAM4-JAX aerosol core, which turns on \`jax_enable_x64\` for its microphysics.

## Fix

Pin the false branch's dtype to \`minor_start_idx.dtype\` so both branches match regardless of the x64 setting. No behavioural change in the float32 build (int32 either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)