### PR TITLE
feat: per-call sfc_alb / sfc_emis overrides on compute_heating_rate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "jax-rrtmgp"
 description = "JAX-based implementation of RRTMGP radiative transfer for atmospheric modeling."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.1.0"
+version = "0.2.1"
 license = {file = "LICENSE"}
 authors = [
     {name = "parkerjeff", email="parkerjeff@google.com"},

--- a/rrtmgp/rrtmgp.py
+++ b/rrtmgp/rrtmgp.py
@@ -120,8 +120,6 @@ class RRTMGP:
       use_scan: bool = False,
       zenith: float | None = None,
       irrad: float | None = None,
-      sfc_alb: float | Array | None = None,
-      sfc_emis: float | Array | None = None,
       cloud_path_liq_lw_per_gpt: Array | None = None,
       cloud_path_ice_lw_per_gpt: Array | None = None,
       cloud_path_liq_sw_per_gpt: Array | None = None,
@@ -129,6 +127,11 @@ class RRTMGP:
       vmr_fields: dict[str, Array] | None = None,
       aerosol_optics_lw: dict[str, Array] | None = None,
       aerosol_optics_sw: dict[str, Array] | None = None,
+      # New optional parameters go at the END of the signature so existing
+      # positional callers (e.g. of the McICA cloud-path arrays) keep their
+      # bindings.
+      sfc_alb: float | Array | None = None,
+      sfc_emis: float | Array | None = None,
   ) -> dict[str, Array]:
     """Compute the local heating rate due to radiative transfer.
 

--- a/rrtmgp/rrtmgp.py
+++ b/rrtmgp/rrtmgp.py
@@ -120,6 +120,8 @@ class RRTMGP:
       use_scan: bool = False,
       zenith: float | None = None,
       irrad: float | None = None,
+      sfc_alb: float | Array | None = None,
+      sfc_emis: float | Array | None = None,
       cloud_path_liq_lw_per_gpt: Array | None = None,
       cloud_path_ice_lw_per_gpt: Array | None = None,
       cloud_path_liq_sw_per_gpt: Array | None = None,
@@ -141,6 +143,14 @@ class RRTMGP:
     cloud paths derived from `q_liq` and `q_ice` inside the per-g-point loop,
     so each g-point sees its own stochastic sub-column. The clear-sky branch
     is unaffected.
+
+    The surface boundary condition can be overridden per call via `sfc_alb`
+    (broadband SW surface albedo) and `sfc_emis` (broadband LW surface
+    emissivity). Like `zenith`/`irrad`, these replace the corresponding
+    `AtmosphericStateCfg` scalars for this call only, and may be traced
+    values — e.g. per-column albedos from a host model's surface scheme
+    under vmap. Anything broadcastable against the `[nx, ny]` surface plane
+    is accepted. When omitted, the configured scalars are used.
 
     Per-cell gas concentrations can be supplied via `vmr_fields`, a dict keyed
     by chemical formula (e.g. `'o3'`, `'co2'`, `'ch4'`, `'n2o'`) mapping to a
@@ -173,11 +183,23 @@ class RRTMGP:
         'lw_flux_down_full': Full longwave downward flux profile [W/m²]
     """
     atm_state = self.atmospheric_state
-    if zenith is not None or irrad is not None:
+    if (
+        zenith is not None
+        or irrad is not None
+        or sfc_alb is not None
+        or sfc_emis is not None
+    ):
+      # Per-call overrides of the configured atmospheric-state scalars.
+      # `sfc_alb` / `sfc_emis` may be traced per-column values (e.g. from a
+      # host model's surface scheme under vmap); the solvers broadcast them
+      # against the horizontal plane, so anything broadcastable against the
+      # `[nx, ny]` surface works.
       atm_state = dataclasses.replace(
           atm_state,
           **({"zenith": zenith} if zenith is not None else {}),
           **({"irrad": irrad} if irrad is not None else {}),
+          **({"sfc_alb": sfc_alb} if sfc_alb is not None else {}),
+          **({"sfc_emis": sfc_emis} if sfc_emis is not None else {}),
       )
 
     # Temperature may have NaNs in the halos (this is intentional).  These NaNs


### PR DESCRIPTION
Adds optional `sfc_alb` / `sfc_emis` keyword args to `RRTMGP.compute_heating_rate`, threaded through the same `dataclasses.replace` hook `zenith`/`irrad` already use. The two-stream solvers already broadcast `atmos_state.sfc_alb`/`sfc_emis` against the horizontal plane, so per-column traced scalars (e.g. from a host model's surface scheme under vmap) work with no solver changes. The clear-sky diagnostic branch reuses the same replaced state and picks the overrides up automatically. Backward compatible — omitted args keep the configured `AtmosphericStateCfg` scalars.

Motivation (jax-gcm): the ECHAM surface tiles compute ice/snow/land albedos (0.15–0.85), but the SW column was always solved with the hardcoded `sfc_alb=0.07` — severing the ice-albedo feedback and breaking surface/atmosphere energy consistency (the surface absorbs SW·(1−albedo_tile) while the column was solved with 0.07). jax-gcm PR climate-analytics-lab/jax-gcm#548 (radiation quick wins) consumes this hook and pins it with regression tests (`test_surface_albedo_reaches_sw_solver`, `test_surface_emissivity_reaches_lw_solver`).

Would need a 0.2.1 release for jax-gcm CI to pick it up (`requirements.txt` there now pins `jax-rrtmgp>=0.2.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)